### PR TITLE
fix: use map instead of array for examples to align OpenAPI Spec

### DIFF
--- a/src/DefinitionGenerator.ts
+++ b/src/DefinitionGenerator.ts
@@ -224,7 +224,7 @@ export class DefinitionGenerator {
 
         if (parameter.example) {
           parameterConfig.example = parameter.example;
-        } else if (parameter.examples && Array.isArray(parameter.examples)) {
+        } else if (parameter.examples) {
           parameterConfig.examples = parameter.examples;
         }
 
@@ -273,9 +273,8 @@ export class DefinitionGenerator {
         if (requestModel) {
           const reqModelConfig = {
             schema: {
-              $ref: `#/components/schemas/${
-                documentationConfig.requestModels[requestModelType]
-              }`
+              $ref: `#/components/schemas/${documentationConfig.requestModels[requestModelType]
+                }`
             }
           };
 
@@ -304,7 +303,7 @@ export class DefinitionGenerator {
   }
 
   private attachExamples(target, config) {
-    if (target.examples && Array.isArray(target.examples)) {
+    if (target.examples) {
       _.merge(config, { examples: _.cloneDeep(target.examples) });
     } else if (target.example) {
       _.merge(config, { example: _.cloneDeep(target.example) });

--- a/src/ServerlessOpenApiDocumentation.ts
+++ b/src/ServerlessOpenApiDocumentation.ts
@@ -65,14 +65,20 @@ export class ServerlessOpenApiDocumentation {
             options: {
               output: {
                 usage: "Output file location [default: openapi.yml|json]",
+                type: "string",
+                required: false,
                 shortcut: "o"
               },
               format: {
                 usage: "OpenAPI file format (yml|json) [default: yml]",
+                type: "string",
+                required: false,
                 shortcut: "f"
               },
               indent: {
                 usage: "File indentation in spaces [default: 2]",
+                type: "string",
+                required: false,
                 shortcut: "i"
               }
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface Model {
   description: string;
   contentType: string;
   schema: string | JSONSchema7;
-  examples: Array<any>;
+  examples: Map<string, any>;
   example: object;
 }
 
@@ -72,7 +72,7 @@ export interface ParameterConfig {
   explode?: boolean;
   allowReserved?: boolean;
   example?: any;
-  examples?: Array<any>;
+  examples?: Map<string, any>;
   content?: Map<string, any>;
 }
 


### PR DESCRIPTION
Ref #8 